### PR TITLE
Fix server build issues and document extern setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# NewWay2
+
+This repository contains the client and server sources for a Metin2-based project.
+
+## External dependencies
+
+The Visual Studio and server builds expect a directory named `Extern` at the repository
+root containing third-party headers and libraries. If you cloned the repository
+without these files, extract them from `Extern.tgz` as described in
+`server/README-SERVER.txt`:
+
+```bash
+tar -xzf Extern.tgz
+```
+
+Place the resulting `Extern` directory alongside the `Client` and `server`
+folders so that paths such as `../../Extern/include` resolve during compilation.

--- a/server/Srcs/Server/libpoly/Makefile
+++ b/server/Srcs/Server/libpoly/Makefile
@@ -4,7 +4,11 @@ BIN = ./libpoly.a
 GCC_VERSION = $(shell $(CC) --version 2>&1 | grep "(GCC)" | cut -d' ' -f3  | cut -d'.' -f1)
 
 INCLUDE =
-INCLUDE += -I../../Extern/include
+# Include directory for external libraries. This path was previously
+# relative to "server/Srcs", which resulted in a missing header error
+# for <msl/random.h>.  Adjust the path so it points to the repository
+# level "Extern" directory when building from this subdirectory.
+INCLUDE += -I../../../../Extern/include
 LIBS =
 
 CFLAGS  = -m32 -Wall -O2 -pipe -fno-exceptions -fno-rtti $(INCLUDE)

--- a/server/Srcs/Server/libsql/AsyncSQL.cpp
+++ b/server/Srcs/Server/libsql/AsyncSQL.cpp
@@ -135,7 +135,11 @@ bool CAsyncSQL::Connect()
 		return false;
 	}
 
-	my_bool reconnect = true;
+
+       // MySQL 8.x removed the deprecated `my_bool` type. Using `bool` ensures
+       // compatibility with recent client libraries while still working with
+       // older versions.
+       bool reconnect = true;
 
 	if (0 != mysql_options(&m_hDB, MYSQL_OPT_RECONNECT, &reconnect))
 		fprintf(stderr, "mysql_option: %s\n", mysql_error(&m_hDB));


### PR DESCRIPTION
## Summary
- fix compile error in `AsyncSQL.cpp` with MySQL 8 by using `bool`
- correct include path for `libpoly`
- document extern folder requirement

## Testing
- `make` *(fails: missing struct members in fdwatch.c)*

------
https://chatgpt.com/codex/tasks/task_e_686da2d3904083218e035960f7f64cdc